### PR TITLE
Bug fixes and usability improvements

### DIFF
--- a/adservices_cli/adservices.py
+++ b/adservices_cli/adservices.py
@@ -47,6 +47,7 @@ class AdServices:
     self.custom_audience = custom_audience.CustomAudience(adb_client)
     self.ad_selection = ad_selection.AdSelection(adb_client)
     self.app_signals = app_signals.AppSignals(adb_client)
+    self.dev_session = dev_session.DevSession(adb_client)
 
   def status(self):
     """Print details about running adservices.
@@ -105,7 +106,7 @@ class AdServices:
   def enable(
       self,
       feature_name: str = flag_constants.FEATURE_ALL,
-      disable_flag_push: bool = False,
+      disable_flag_push: bool = True,
   ):
     """Enable the adservices process and flags for either all features or a specific feature provided.
 
@@ -268,7 +269,7 @@ class AdServices:
       )
 
     self.adb.set_sync_disabled_for_tests(
-        "persistent" if enabled and disable_flag_push else "none",
+        "until_reboot" if disable_flag_push else "none",
     )
 
     if enabled:

--- a/adservices_cli/custom_audience.py
+++ b/adservices_cli/custom_audience.py
@@ -141,13 +141,18 @@ class CustomAudience:
       updated_custom_audience = json.loads(
           self._do_get_custom_audience(name, owner_app_package, buyer)
       )
+      diff_in_ca = json.loads(
+          jsondiff.diff(
+              existing_custom_audience,
+              updated_custom_audience,
+              syntax="explicit",
+              dump=True,
+          )
+      )
       return json.dumps(
           {
               "existing_custom_audience": existing_custom_audience,
-              "updated_fields": jsondiff.diff(
-                  existing_custom_audience,
-                  updated_custom_audience,
-              ),
+              "updated_fields": diff_in_ca,
           },
           indent=4,
       )

--- a/adservices_cli/custom_audience_test.py
+++ b/adservices_cli/custom_audience_test.py
@@ -23,24 +23,25 @@ import utilities
 _TEST_NAME = 'test_name'
 _TEST_INSTALLED_OWNER_PACKAGE = 'com.example.test'
 _TEST_BUYER = 'com.example'
-_TEST_CUSTOM_AUDIENCE_NAME = 'test_custom_audience_name'
-_TEST_CUSTOM_AUDIENCE = {
-    'name': _TEST_CUSTOM_AUDIENCE_NAME,
-    'field': 'test_data',
-}
-_TEST_CUSTOM_AUDIENCE_MODIFIED = {
-    'name': _TEST_CUSTOM_AUDIENCE_NAME,
-    'field': 'modified_test_data',
-}
+
+_TEST_CUSTOM_AUDIENCE = json.loads(
+    '{"name":"shoes","owner":"com.example.adservices.samples.fledge.sampleapp","buyer":"buyer-example.com","daily_update":{"uri":"https://buyer-example.com/dailyupdate/shoes","eligible_update_time":"2025-01-16T14:13:23.245Z","num_validation_failures":0,"num_timeout_failures":0},"is_debuggable":true,"creation_time":"2025-01-15T14:13:23.245Z","activation_time":"2025-01-15T14:13:23.245Z","expiration_time":"2025-03-16T14:13:23.245Z","updated_time":"2025-01-15T14:13:23.245Z","bidding_logic_uri":"https://buyer-example.com/buyer/bidding/simple_logic","user_bidding_signals":"{}","is_eligible_for_on_device_auction":true,"is_eligible_for_server_auction":false,"uri":"https://buyer-example.com/dailyupdate/shoes","trusted_bidding_data":{"uri":"https://buyer-example.com/bidding/trusted","keys":["shoes","buyer-example.com","key1","key2"]},"ads":[{"render_uri":"https://buyer-example.com/buyer/bidding/render_shoes","metadata":"{}","ad_counter_keys":[]}]}'
+)
+
+_TEST_CUSTOM_AUDIENCE_MODIFIED = json.loads(
+    '{"name":"shoes","owner":"com.example.adservices.samples.fledge.sampleapp","buyer":"buyer-example.com","daily_update":{"uri":"https://buyer-example.com/dailyupdate/shoes","eligible_update_time":"2025-01-16T14:15:28.050Z","num_validation_failures":0,"num_timeout_failures":0},"is_debuggable":true,"creation_time":"2025-01-15T14:13:23.245Z","activation_time":"2025-01-15T14:13:23.245Z","expiration_time":"2025-03-16T14:13:23.245Z","updated_time":"2025-01-15T14:15:28.050Z","bidding_logic_uri":"https://buyer-example.com/buyer/bidding/simple_logic","user_bidding_signals":{"valid":true,"arbitrary":"yes"},"is_eligible_for_on_device_auction":true,"is_eligible_for_server_auction":false,"uri":"https://buyer-example.com/dailyupdate/shoes","trusted_bidding_data":{"uri":"https://buyer-example.com/trusted/biddingsignals/simple","keys":["key1","key2"]},"ads":[{"render_uri":"https://buyer-example.com/render/shoes/ad0?date=2025-01-15","metadata":{"bid":1},"ad_counter_keys":[]},{"render_uri":"https://buyer-example.com/render/shoes/ad1?date=2025-01-15","metadata":{"bid":2},"ad_counter_keys":[]},{"render_uri":"https://buyer-example.com/render/shoes/ad2?date=2025-01-15","metadata":{"bid":3},"ad_counter_keys":[]},{"render_uri":"https://buyer-example.com/render/shoes/ad3?date=2025-01-15","metadata":{"bid":4},"ad_counter_keys":[]},{"render_uri":"https://buyer-example.com/render/shoes/ad4?date=2025-01-15","metadata":{"bid":5},"ad_counter_keys":[]}]}'
+)
+
+_REFRESH_COM_EXPECTED_OUTPUT = json.loads(
+    '{"existing_custom_audience":{"name":"shoes","owner":"com.example.adservices.samples.fledge.sampleapp","buyer":"buyer-example.com","daily_update":{"uri":"https://buyer-example.com/dailyupdate/shoes","eligible_update_time":"2025-01-16T14:13:23.245Z","num_validation_failures":0,"num_timeout_failures":0},"is_debuggable":true,"creation_time":"2025-01-15T14:13:23.245Z","activation_time":"2025-01-15T14:13:23.245Z","expiration_time":"2025-03-16T14:13:23.245Z","updated_time":"2025-01-15T14:13:23.245Z","bidding_logic_uri":"https://buyer-example.com/buyer/bidding/simple_logic","user_bidding_signals":"{}","is_eligible_for_on_device_auction":true,"is_eligible_for_server_auction":false,"uri":"https://buyer-example.com/dailyupdate/shoes","trusted_bidding_data":{"uri":"https://buyer-example.com/bidding/trusted","keys":["shoes","buyer-example.com","key1","key2"]},"ads":[{"render_uri":"https://buyer-example.com/buyer/bidding/render_shoes","metadata":"{}","ad_counter_keys":[]}]},"updated_fields":{"$update":{"daily_update":{"$update":{"eligible_update_time":"2025-01-16T14:15:28.050Z"}},"updated_time":"2025-01-15T14:15:28.050Z","user_bidding_signals":{"valid":true,"arbitrary":"yes"},"trusted_bidding_data":{"$update":{"uri":"https://buyer-example.com/trusted/biddingsignals/simple","keys":{"$delete":[1,0]}}},"ads":{"4":{"$update":{"render_uri":"https://buyer-example.com/render/shoes/ad4?date=2025-01-15","metadata":{"bid":5}}},"$insert":[[0,{"render_uri":"https://buyer-example.com/render/shoes/ad0?date=2025-01-15","metadata":{"bid":1},"ad_counter_keys":[]}],[1,{"render_uri":"https://buyer-example.com/render/shoes/ad1?date=2025-01-15","metadata":{"bid":2},"ad_counter_keys":[]}],[2,{"render_uri":"https://buyer-example.com/render/shoes/ad2?date=2025-01-15","metadata":{"bid":3},"ad_counter_keys":[]}],[3,{"render_uri":"https://buyer-example.com/render/shoes/ad3?date=2025-01-15","metadata":{"bid":4},"ad_counter_keys":[]}]]}}}}'
+)
 
 _LIST_AUDIENCES_RESPONSE = {'audiences': [_TEST_CUSTOM_AUDIENCE]}
 _LIST_AUDIENCES_RESPONSE_EMPTY = {'audiences': []}
 _REFRESH_AUDIENCE_RESPONSE = {}
-_GET_AUDIENCE_RESPONSE = {'audiences': [_TEST_CUSTOM_AUDIENCE]}
-_GET_AUDIENCE_RESPONSE_MODIFIED = {
-    'audiences': [_TEST_CUSTOM_AUDIENCE_MODIFIED]
-}
-_GET_AUDIENCE_RESPONSE_EMPTY = {'audiences': []}
+_GET_AUDIENCE_RESPONSE = _TEST_CUSTOM_AUDIENCE
+_GET_AUDIENCE_RESPONSE_MODIFIED = _TEST_CUSTOM_AUDIENCE_MODIFIED
+_GET_AUDIENCE_RESPONSE_EMPTY = {}
 
 
 class CustomAudienceTest(absltest.TestCase):
@@ -148,7 +149,7 @@ class CustomAudienceTest(absltest.TestCase):
     self.adb.set_shell_outputs([
         json.dumps(_GET_AUDIENCE_RESPONSE),
         json.dumps(_REFRESH_AUDIENCE_RESPONSE),
-        json.dumps(json.dumps(_GET_AUDIENCE_RESPONSE_MODIFIED)),
+        json.dumps(_GET_AUDIENCE_RESPONSE_MODIFIED),
     ])
 
     diffed_json = json.loads(
@@ -158,12 +159,7 @@ class CustomAudienceTest(absltest.TestCase):
             buyer=_TEST_BUYER,
         )
     )
-
-    self.assertEqual(
-        diffed_json['updated_fields'],
-        '{"audiences": [{"name": "test_custom_audience_name", "field":'
-        ' "modified_test_data"}]}',
-    )
+    self.assertEqual(diffed_json, _REFRESH_COM_EXPECTED_OUTPUT)
     parts = utilities.split_adb_command(custom_audience._COMMAND_PREFIX) + [
         custom_audience._ARG_OWNER,
         _TEST_INSTALLED_OWNER_PACKAGE,

--- a/adservices_cli/e2e_test.py
+++ b/adservices_cli/e2e_test.py
@@ -52,6 +52,14 @@ class AdServicesTest(absltest.TestCase):
 
     self.adb.put_device_config.assert_called()
     self.adb.setprop.assert_called()
+    self.adb.set_sync_disabled_for_tests.assert_called_once_with('until_reboot')
+
+  def test_enable_disable_flag_push_is_false(self):
+    self.adservices.enable(flag_constants.FEATURE_ALL, False)
+
+    self.adb.put_device_config.assert_called()
+    self.adb.setprop.assert_called()
+    self.adb.set_sync_disabled_for_tests.assert_called_once_with('none')
 
   def test_enable_invalid_argument(self):
     try:
@@ -76,6 +84,7 @@ class AdServicesTest(absltest.TestCase):
 
     self.adb.put_device_config.assert_called()
     self.adb.setprop.assert_called()
+    self.adb.set_sync_disabled_for_tests.assert_called_once_with('none')
 
   def test_disable_invalid_argument(self):
     try:

--- a/adservices_cli/flag_constants.py
+++ b/adservices_cli/flag_constants.py
@@ -82,12 +82,13 @@ _ENABLE_EVENT_LEVEL_DEBUG_REPORT_SEND_IMMEDIATELY = (
     "fledge_event_level_debug_report_send_immediately"
 )
 _ENABLE_CONTEXTUAL_ADS_FILTER = "fledge_ad_selection_contextual_ads_enabled"
-
+_ENABLE_HTTP_CACHE_ENABLE_JS_CACHING = "fledge_http_cache_enable_js_caching"
 ENABLE_ALL_ON_DEVICE_AD_SELECTION_FLAGS = [
     _ENABLE_AD_SELECTION_PREBUILT_URI,
     _ENABLE_EVENT_LEVEL_DEBUG_REPORTING,
     _ENABLE_EVENT_LEVEL_DEBUG_REPORT_SEND_IMMEDIATELY,
     _ENABLE_CONTEXTUAL_ADS_FILTER,
+    _ENABLE_HTTP_CACHE_ENABLE_JS_CACHING,
 ]
 
 ### Server auctions
@@ -185,6 +186,7 @@ FEATURE_FLAGS_MAP = {
 ## AdServices debug flags
 _DISABLE_FLEDGE_ENROLLMENT_CHECK = "disable_fledge_enrollment_check"
 _CONSENT_MANAGER_DEBUG_MODE = "consent_manager_debug_mode"
+_CONSENT_NOTIFICATION_DEBUG_MODE = "consent_notification_debug_mode"
 _ENABLE_ADSERVICES_SHELL = "adservices_shell_command_enabled"
 _ENABLE_CUSTOM_AUDIENCE_CLI = "fledge_is_custom_audience_cli_enabled"
 _ENABLE_JS_COLSOLE_LOGS = (
@@ -196,10 +198,13 @@ _ENABLE_SERVER_AUCTION_CONSENTED_DEBUGGING = (
     "fledge_auction_server_consented_debugging_enabled"
 )
 _ENABLE_PROTECTED_APP_SIGNALS_CLI = "fledge_is_app_signals_cli_enabled"
+_ENABLE_MEASUREMENT_ATTRIBUTION_REPORTING_CLI = "measurement_attribution_reporting_cli_enabled"
+_ENABLE_DEV_SESSION_FEATURE = "developer_session_feature_enabled"
 
 DEBUG_FLAGS = [
     _DISABLE_FLEDGE_ENROLLMENT_CHECK,
     _CONSENT_MANAGER_DEBUG_MODE,
+    _CONSENT_NOTIFICATION_DEBUG_MODE,
     _ENABLE_ADSERVICES_SHELL,
     _ENABLE_AD_SELECTION_CLI,
     _ENABLE_CONSENTED_DEBUGGING,
@@ -207,6 +212,8 @@ DEBUG_FLAGS = [
     _ENABLE_JS_COLSOLE_LOGS,
     _ENABLE_CUSTOM_AUDIENCE_CLI,
     _ENABLE_PROTECTED_APP_SIGNALS_CLI,
+    _ENABLE_MEASUREMENT_ATTRIBUTION_REPORTING_CLI,
+    _ENABLE_DEV_SESSION_FEATURE,
 ]
 
 # AdServices allow lists
@@ -219,6 +226,10 @@ LOG_TAGS_FOR_VERBOSE_LOGGING = [
     "adservices.fledge",
     "adservices.topics",
     "adservices.kanon",
+    "adservices.measurement",
+    "adservices.ui",
+    "adservices.adid",
+    "adservices.appsetid",
     "AdServicesShellCmd",
     "FledgeSample",
 ]


### PR DESCRIPTION
Several bug fixes and usability improvements:
- Now `disable_flag_push` is on by default, and pushes will be disabled until the device is rebooted
- Corrected updated fields list when refreshing a custom audience
- Set new debug flags:
  - `fledge_http_cache_enable_js_caching`
  - `consent_notification_debug_mode`
  - `measurement_attribution_reporting_cli_enabled`
  - `developer_session_feature_enabled`
- Add new verbose log tags:
  - `adservices.measurement`
  - `adservices.ui`
  - `adservices.adid`
  - `adservices.appsetid`